### PR TITLE
[discussion][do not merge] actors + channels architecture

### DIFF
--- a/src/accel.rs
+++ b/src/accel.rs
@@ -1,0 +1,88 @@
+//! The accel-related traits and actor.
+
+use std::marker::PhantomData;
+use std::sync::mpsc;
+use std::thread;
+
+/// Raw, unprocessed accel data.
+pub struct RawAccelData(u64);
+
+/// Munged, processed accel data.
+pub struct ProcessedAccelData(u64);
+
+/// Anything that can provide raw accel data.
+///
+/// In tests, we can mock this trait to return whatever sequence of raw accel
+/// data we want. For the real deal, this would perform IO directly.
+pub trait AccelSource {
+    fn read_accel(&self) -> RawAccelData;
+}
+
+/// Anything that can make use of processed accel data.
+///
+/// In tests, we would mock this to assert our expectations for processed data
+/// based on whatever test data our mocked source was feeding in. For the real
+/// deal, this would forward data as input to other actors.
+pub trait AccelSink {
+    fn send_accel(&self, data: ProcessedAccelData);
+}
+
+// For exposition.
+impl AccelSource for mpsc::Receiver<RawAccelData> {
+    fn read_accel(&self) -> RawAccelData {
+        self.recv().unwrap()
+    }
+}
+
+// For exposition, although we would probably want to really use something like
+// this for a channel sender to sensor fusion.
+impl<T> AccelSink for mpsc::Sender<T>
+    where T: From<ProcessedAccelData>
+{
+    fn send_accel(&self, data: ProcessedAccelData) {
+        self.send(data.into()).unwrap()
+    }
+}
+
+/// A AccelActor is just a handle to the thread running the accel processing loop.
+pub struct AccelActor<Source, Sink> {
+    source: PhantomData<Source>,
+    sink: PhantomData<Sink>,
+}
+
+impl<Source, Sink> AccelActor<Source, Sink>
+    where Source: 'static + AccelSource + Send,
+          Sink: 'static + AccelSink + Send
+{
+    /// Spawn the accel processing loop in its own thread, and get back the
+    /// AccelActor handle to it.
+    pub fn spawn(source: Source, sink: Sink) -> AccelActor<Source, Sink> {
+        thread::spawn(move || AccelActor::run(source, sink));
+        AccelActor {
+            source: PhantomData,
+            sink: PhantomData,
+        }
+    }
+
+    // TODO: Maybe add a method to shut down this actor? Could use atomics or a
+    // channel or something else.
+
+    fn run(source: Source, sink: Sink) {
+        loop {
+            // TODO: check if we've been requested to terminate or something.
+            AccelActor::process(&source, &sink);
+            // TODO: delay between processing samples?
+        }
+    }
+
+    fn process(source: &Source, sink: &Sink) {
+        // Do whatever munging, massaging, and processing to go from raw to
+        // processed accel data... This is the main function to unit test, most
+        // everything else is boilerplate that we'd like to abstract out between
+        // all actors once we know a little more about precisely what we are
+        // doing.
+        let raw = source.read_accel();
+        let processed = ProcessedAccelData(raw.0);
+        sink.send_accel(processed);
+    }
+}

--- a/src/fusion.rs
+++ b/src/fusion.rs
@@ -1,0 +1,139 @@
+//! The traits and actor related to sensor fusion.
+
+use accel;
+use gyro;
+use mag;
+use std::marker::PhantomData;
+use std::sync::mpsc;
+use std::thread;
+
+/// The input to sensor fusion is all of our various kinds of sensor data.
+pub enum SensorInput {
+    /// Input from the accel sensor.
+    Accel(accel::ProcessedAccelData),
+
+    /// Input from the gyro sensor.
+    Gyro(gyro::ProcessedGyroData),
+
+    /// Input from the mag sensor.
+    Mag(mag::ProcessedMagData),
+}
+
+// A bunch of type conversion trait implementation glue so that this can be used
+// with the `impl<T> {Gyro,Mag,Accel}Sink for mpsc::Sender<T>` implementations.
+
+impl From<accel::ProcessedAccelData> for SensorInput {
+    fn from(data: accel::ProcessedAccelData) -> Self {
+        SensorInput::Accel(data)
+    }
+}
+
+impl From<gyro::ProcessedGyroData> for SensorInput {
+    fn from(data: gyro::ProcessedGyroData) -> Self {
+        SensorInput::Gyro(data)
+    }
+}
+
+impl From<mag::ProcessedMagData> for SensorInput {
+    fn from(data: mag::ProcessedMagData) -> Self {
+        SensorInput::Mag(data)
+    }
+}
+
+/// Anything that can provide sensor input data.
+///
+/// In tests, we can mock this trait to return whatever sequence of sensor input
+/// data we want. For the real deal, this would use mpsc channels to talk to the
+/// actors performing IO and processing raw data from the real sensors.
+pub trait SensorInputSource {
+    fn read_sensor_input(&self) -> SensorInput;
+}
+
+// For exposition.
+impl SensorInputSource for mpsc::Receiver<SensorInput> {
+    fn read_sensor_input(&self) -> SensorInput {
+        self.recv().unwrap()
+    }
+}
+
+/// The output of sensor fusion.
+#[derive(Clone, Default)]
+pub struct FusedSensorOutput {
+    // Whatever fused output looks like...
+}
+
+impl FusedSensorOutput {
+    /// Fuse more sensor input data into this fused output.
+    pub fn join(self, _more_input: SensorInput) -> FusedSensorOutput {
+        // TODO: actually fuse data...
+        self
+    }
+}
+
+/// Anything that wants to use the fused sensor output.
+///
+/// In tests, we would mock this to assert our expectations for fused output
+/// given the test input from different mocked sensors that collectively
+/// implement a mocked SensorInputSource. For the real deal, this would forward
+/// data to the flight controller, probably along an mpsc channel.
+pub trait SensorOutputSink {
+    /// Send the fused sensor output to the sink.
+    fn send_sensor_output(&self, output: FusedSensorOutput);
+}
+
+// For exposition, although we would probably want to really use something like
+// this for a channel sender to flight control.
+impl<T> SensorOutputSink for mpsc::Sender<T>
+    where T: From<FusedSensorOutput>
+{
+    fn send_sensor_output(&self, output: FusedSensorOutput) {
+        self.send(output.into()).unwrap()
+    }
+}
+
+/// A SensorFusionActor is just a handle to the thread running the sensor fusion
+/// loop.
+pub struct SensorFusionActor<Source, Sink> {
+    source: PhantomData<Source>,
+    sink: PhantomData<Sink>,
+}
+
+impl<Source, Sink> SensorFusionActor<Source, Sink>
+    where Source: 'static + SensorInputSource + Send,
+          Sink: 'static + SensorOutputSink + Send
+{
+    /// Spawn the sensor fusion processing loop in its own thread, and get back
+    /// the SensorFusionActor handle to it.
+    pub fn spawn(source: Source, sink: Sink) -> SensorFusionActor<Source, Sink> {
+        thread::spawn(move || SensorFusionActor::run(source, sink));
+        SensorFusionActor {
+            source: PhantomData,
+            sink: PhantomData,
+        }
+    }
+
+    // TODO: Maybe add a method to shut down this actor? Could use atomics or a
+    // channel or something else.
+
+    fn run(source: Source, sink: Sink) {
+        let mut data = FusedSensorOutput::default();
+        loop {
+            // TODO: check if we've been requested to terminate or something.
+            data = SensorFusionActor::process(data, &source, &sink);
+        }
+    }
+
+    fn process(data: FusedSensorOutput, source: &Source, sink: &Sink) -> FusedSensorOutput {
+        // Do whatever sensor input fusion... This is the main function to unit
+        // test, most everything else is boilerplate that we'd like to abstract
+        // out between all actors once we know a little more about precisely
+        // what we are doing.
+        //
+        // Note that this takes and returns the state it wants to persist,
+        // unlike say the GyroActor which does not persist any state.
+        let input = source.read_sensor_input();
+        let fused = data.join(input);
+        sink.send_sensor_output(fused.clone());
+        fused
+    }
+}

--- a/src/gyro.rs
+++ b/src/gyro.rs
@@ -1,0 +1,88 @@
+//! The gyro-related traits and actor.
+
+use std::marker::PhantomData;
+use std::sync::mpsc;
+use std::thread;
+
+/// Raw, unprocessed gyro data.
+pub struct RawGyroData(u64);
+
+/// Munged, processed gyro data.
+pub struct ProcessedGyroData(u64);
+
+/// Anything that can provide raw gyro data.
+///
+/// In tests, we can mock this trait to return whatever sequence of raw gyro
+/// data we want. For the real deal, this would perform IO directly.
+pub trait GyroSource {
+    fn read_gyro(&self) -> RawGyroData;
+}
+
+/// Anything that can make use of processed gyro data.
+///
+/// In tests, we would mock this to assert our expectations for processed data
+/// based on whatever test data our mocked source was feeding in. For the real
+/// deal, this would forward data as input to other actors.
+pub trait GyroSink {
+    fn send_gyro(&self, data: ProcessedGyroData);
+}
+
+// For exposition.
+impl GyroSource for mpsc::Receiver<RawGyroData> {
+    fn read_gyro(&self) -> RawGyroData {
+        self.recv().unwrap()
+    }
+}
+
+// For exposition, although we would probably want to really use something like
+// this for a channel sender to sensor fusion.
+impl<T> GyroSink for mpsc::Sender<T>
+    where T: From<ProcessedGyroData>
+{
+    fn send_gyro(&self, data: ProcessedGyroData) {
+        self.send(data.into()).unwrap()
+    }
+}
+
+/// A GyroActor is just a handle to the thread running the gyro processing loop.
+pub struct GyroActor<Source, Sink> {
+    source: PhantomData<Source>,
+    sink: PhantomData<Sink>,
+}
+
+impl<Source, Sink> GyroActor<Source, Sink>
+    where Source: 'static + GyroSource + Send,
+          Sink: 'static + GyroSink + Send
+{
+    /// Spawn the gyro processing loop in its own thread, and get back the
+    /// GyroActor handle to it.
+    pub fn spawn(source: Source, sink: Sink) -> GyroActor<Source, Sink> {
+        thread::spawn(move || GyroActor::run(source, sink));
+        GyroActor {
+            source: PhantomData,
+            sink: PhantomData,
+        }
+    }
+
+    // TODO: Maybe add a method to shut down this actor? Could use atomics or a
+    // channel or something else.
+
+    fn run(source: Source, sink: Sink) {
+        loop {
+            // TODO: check if we've been requested to terminate or something.
+            GyroActor::process(&source, &sink);
+            // TODO: delay between processing samples?
+        }
+    }
+
+    fn process(source: &Source, sink: &Sink) {
+        // Do whatever munging, massaging, and processing to go from raw to
+        // processed gyro data... This is the main function to unit test, most
+        // everything else is boilerplate that we'd like to abstract out between
+        // all actors once we know a little more about precisely what we are
+        // doing.
+        let raw = source.read_gyro();
+        let processed = ProcessedGyroData(raw.0);
+        sink.send_gyro(processed);
+    }
+}

--- a/src/mag.rs
+++ b/src/mag.rs
@@ -1,0 +1,88 @@
+//! The mag-related traits and actor.
+
+use std::marker::PhantomData;
+use std::sync::mpsc;
+use std::thread;
+
+/// Raw, unprocessed mag data.
+pub struct RawMagData(u64);
+
+/// Munged, processed mag data.
+pub struct ProcessedMagData(u64);
+
+/// Anything that can provide raw mag data.
+///
+/// In tests, we can mock this trait to return whatever sequence of raw mag
+/// data we want. For the real deal, this would perform IO directly.
+pub trait MagSource {
+    fn read_mag(&self) -> RawMagData;
+}
+
+/// Anything that can make use of processed mag data.
+///
+/// In tests, we would mock this to assert our expectations for processed data
+/// based on whatever test data our mocked source was feeding in. For the real
+/// deal, this would forward data as input to other actors.
+pub trait MagSink {
+    fn send_mag(&self, data: ProcessedMagData);
+}
+
+// For exposition.
+impl MagSource for mpsc::Receiver<RawMagData> {
+    fn read_mag(&self) -> RawMagData {
+        self.recv().unwrap()
+    }
+}
+
+// For exposition, although we would probably want to really use something like
+// this for a channel sender to sensor fusion.
+impl<T> MagSink for mpsc::Sender<T>
+    where T: From<ProcessedMagData>
+{
+    fn send_mag(&self, data: ProcessedMagData) {
+        self.send(data.into()).unwrap()
+    }
+}
+
+/// A MagActor is just a handle to the thread running the mag processing loop.
+pub struct MagActor<Source, Sink> {
+    source: PhantomData<Source>,
+    sink: PhantomData<Sink>,
+}
+
+impl<Source, Sink> MagActor<Source, Sink>
+    where Source: 'static + MagSource + Send,
+          Sink: 'static + MagSink + Send,
+{
+    /// Spawn the mag processing loop in its own thread, and get back the
+    /// MagActor handle to it.
+    pub fn spawn(source: Source, sink: Sink) -> MagActor<Source, Sink> {
+        thread::spawn(move || MagActor::run(source, sink));
+        MagActor {
+            source: PhantomData,
+            sink: PhantomData,
+        }
+    }
+
+    // TODO: Maybe add a method to shut down this actor? Could use atomics or a
+    // channel or something else.
+
+    fn run(source: Source, sink: Sink) {
+        loop {
+            // TODO: check if we've been requested to terminate or something.
+            MagActor::process(&source, &sink);
+            // TODO: delay between processing samples?
+        }
+    }
+
+    fn process(source: &Source, sink: &Sink) {
+        // Do whatever munging, massaging, and processing to go from raw to
+        // processed mag data... This is the main function to unit test, most
+        // everything else is boilerplate that we'd like to abstract out between
+        // all actors once we know a little more about precisely what we are
+        // doing.
+        let raw = source.read_mag();
+        let processed = ProcessedMagData(raw.0);
+        sink.send_mag(processed);
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,9 +6,15 @@
 extern crate byteorder;
 extern crate i2cdev;
 
+pub mod gyro;
+pub mod accel;
+pub mod mag;
+pub mod fusion;
+
 use byteorder::{BigEndian, ReadBytesExt};
 use i2cdev::core::*;
 use i2cdev::linux::*;
+
 use std::env;
 use std::error::Error;
 use std::io;


### PR DESCRIPTION
This gives a sketch of what I was imagining last night.

See `src/fusion.rs` and `src/{mag,accel,gyro}.rs` for details. See `SensorInput` in `src/fusion.rs` for how multiplexing across channels with strong typing works.

The use of traits to enable mocking/testing can be pretty much reused even if we don't want to go full threading with actor + channels and instead use polling on a single thread. The one trick is that things will need to be inverted a bit so that data is pushed through, rather than pulled through.

Thoughts @jameysharp @slnovak @jeenalee @malisas ?